### PR TITLE
fix bash path for ubuntu-18.04

### DIFF
--- a/modules/backend/pre-cloud-config.sh
+++ b/modules/backend/pre-cloud-config.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 sed -i -E -e '/^datasource_list:.*/s/.*/datasource_list: [NoCloud]/' /etc/cloud/cloud.cfg
 rm /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
 rm /etc/network/interfaces


### PR DESCRIPTION
In Ubuntu 18.04 the path to bash is /bin/bash.
This PR will rely on /usr/bin/env to choose the correct bash path.